### PR TITLE
ffmpeg: remove deprecated avresample

### DIFF
--- a/ffmpeg.yaml
+++ b/ffmpeg.yaml
@@ -35,7 +35,6 @@ config-opts:
   - --enable-avfilter
   - --enable-filters
   - --enable-avdevice
-  - --enable-avresample
   #- --enable-libxml2
   - --enable-swscale
 


### PR DESCRIPTION
I hope it doesn't break the app.

Deprecation:
https://github.com/FFmpeg/FFmpeg/commit/c29038f3041a4080342b2e333c1967d136749c0f

Removal:
https://github.com/FFmpeg/FFmpeg/commit/420cedd49745b284c35d97b936b71ff79b43bdf7